### PR TITLE
Convert specs to RSpec 3.4.4 syntax with Transpec

### DIFF
--- a/spec/controllers/blog_entries_controller_spec.rb
+++ b/spec/controllers/blog_entries_controller_spec.rb
@@ -6,9 +6,9 @@ describe BlogEntriesController do
     it "paginates the 'published' scope on BlogEntry" do
       blog_entries = []
       per_double = double('per', per: blog_entries)
-      BlogEntry.stub_chain(:published,:with_content,:page).
+      allow(BlogEntry).to receive_message_chain(:published,:with_content,:page).
         with('2').and_return(per_double)
-      BlogEntry.stub_chain(:published,:we_are_reading,:limit).and_return([])
+      allow(BlogEntry).to receive_message_chain(:published,:we_are_reading,:limit).and_return([])
 
       get :index, page: 2
 
@@ -17,10 +17,10 @@ describe BlogEntriesController do
     end
 
     it "includes we_are_reading blog entries" do
-      BlogEntry.stub_chain(:published,:with_content,:page, :per).and_return([])
+      allow(BlogEntry).to receive_message_chain(:published,:with_content,:page, :per).and_return([])
 
       blog_entries = 'blog entries'
-      BlogEntry.stub_chain(:published,:we_are_reading,:limit).and_return(blog_entries)
+      allow(BlogEntry).to receive_message_chain(:published,:we_are_reading,:limit).and_return(blog_entries)
 
       get :index, page: 2
       expect(assigns(:we_are_reading)).to eq blog_entries
@@ -32,9 +32,9 @@ describe BlogEntriesController do
     it "paginates the 'published' scope on BlogEntry" do
       blog_entries = []
       per_double = double('per', per: blog_entries)
-      BlogEntry.stub_chain(:archived,:with_content,:page).
+      allow(BlogEntry).to receive_message_chain(:archived,:with_content,:page).
         with('2').and_return(per_double)
-      BlogEntry.stub_chain(:published,:we_are_reading,:limit).and_return([])
+      allow(BlogEntry).to receive_message_chain(:published,:we_are_reading,:limit).and_return([])
 
       get :archive, page: 2
 
@@ -43,10 +43,10 @@ describe BlogEntriesController do
     end
 
     it "includes we_are_reading blog entries" do
-      BlogEntry.stub_chain(:published,:with_content,:page, :per).and_return([])
+      allow(BlogEntry).to receive_message_chain(:published,:with_content,:page, :per).and_return([])
 
       blog_entries = 'blog entries'
-      BlogEntry.stub_chain(:published,:we_are_reading,:limit).and_return(blog_entries)
+      allow(BlogEntry).to receive_message_chain(:published,:we_are_reading,:limit).and_return(blog_entries)
 
       get :index, page: 2
       expect(assigns(:we_are_reading)).to eq blog_entries
@@ -57,7 +57,7 @@ describe BlogEntriesController do
   context "#show" do
     it "loads a blog entry by ID" do
       blog_entry = double("Blog entry")
-      BlogEntry.should_receive(:find).with('42').and_return(blog_entry)
+      expect(BlogEntry).to receive(:find).with('42').and_return(blog_entry)
 
       get :show, id: 42
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -4,7 +4,7 @@ describe HomeController do
   context "#index" do
     it "finds recent notices" do
       notices = double("Notices")
-      Notice.should_receive(:recent).and_return(notices)
+      expect(Notice).to receive(:recent).and_return(notices)
 
       get :index
 
@@ -14,7 +14,7 @@ describe HomeController do
 
     it "finds recent blog entries" do
       blog_entries = double("Blog entries")
-      BlogEntry.should_receive(:recent_posts).and_return(blog_entries)
+      expect(BlogEntry).to receive(:recent_posts).and_return(blog_entries)
 
       get :index
 

--- a/spec/controllers/notices/search_controller_spec.rb
+++ b/spec/controllers/notices/search_controller_spec.rb
@@ -4,7 +4,7 @@ describe Notices::SearchController do
   context "#index" do
     it "uses SearchesModels" do
       searcher = SearchesModels.new
-      SearchesModels.should_receive(:new).and_return(searcher)
+      expect(SearchesModels).to receive(:new).and_return(searcher)
 
       get :index, { term: 'foo' }
 

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -4,7 +4,7 @@ describe NoticesController do
   context "#show" do
     it "finds the notice by ID" do
       notice = Notice.new
-      Notice.should_receive(:find).with('42').and_return(notice)
+      expect(Notice).to receive(:find).with('42').and_return(notice)
 
       get :show, id: 42
 
@@ -37,7 +37,7 @@ describe NoticesController do
           notice = stub_find_notice(model_class.new)
           serializer_class = model_class.active_model_serializer || NoticeSerializer
           serialized = serializer_class.new(notice)
-          serializer_class.should_receive(:new).
+          expect(serializer_class).to receive(:new).
             with(notice, anything).and_return(serialized)
 
           get :show, id: 1, format: :json
@@ -76,7 +76,7 @@ describe NoticesController do
 
     def stub_find_notice(notice = nil)
       notice ||= Notice.new
-      notice.tap { |n| Notice.stub(:find).and_return(n) }
+      notice.tap { |n| allow(Notice).to receive(:find).and_return(n) }
     end
   end
 
@@ -88,7 +88,7 @@ describe NoticesController do
       end
 
       it "initializes a DMCA by default from params" do
-        SubmitNotice.should_receive(:new).
+        expect(SubmitNotice).to receive(:new).
           with(DMCA, @notice_params).
           and_return(@submit_notice)
 
@@ -96,7 +96,7 @@ describe NoticesController do
       end
 
       it "uses the type param to instantiate the correct class" do
-        SubmitNotice.should_receive(:new).
+        expect(SubmitNotice).to receive(:new).
           with(Trademark, @notice_params).
           and_return(@submit_notice)
 
@@ -106,7 +106,7 @@ describe NoticesController do
       it "defaults to DMCA if the type is missing or invalid" do
         invalid_types = ['', 'FlimFlam', 'Object', 'User', 'Hash']
 
-        SubmitNotice.should_receive(:new).
+        expect(SubmitNotice).to receive(:new).
           exactly(5).times.
           with(DMCA, @notice_params).
           and_return(@submit_notice)
@@ -128,7 +128,7 @@ describe NoticesController do
 
       it "renders the new template when unsuccessful" do
         submit_notice = stub_submit_notice
-        submit_notice.stub(:submit).and_return(false)
+        allow(submit_notice).to receive(:submit).and_return(false)
 
         post_create
 
@@ -142,7 +142,7 @@ describe NoticesController do
         @ability = Object.new
         @ability.extend(CanCan::Ability)
         @ability.can(:submit, Notice)
-        controller.stub(:current_ability) { @ability }
+        allow(controller).to receive(:current_ability) { @ability }
       end
 
       it "returns unauthorized if one cannot submit" do
@@ -157,7 +157,7 @@ describe NoticesController do
       it "returns a proper Location header when saved successfully" do
         notice = build_stubbed(:dmca)
         submit_notice = stub_submit_notice
-        submit_notice.stub(:notice).and_return(notice)
+        allow(submit_notice).to receive(:notice).and_return(notice)
 
         post_create :json
 
@@ -167,7 +167,7 @@ describe NoticesController do
 
       it "returns a useful status code when there are errors" do
         submit_notice = stub_submit_notice
-        submit_notice.stub(:submit).and_return(false)
+        allow(submit_notice).to receive(:submit).and_return(false)
 
         post_create :json
 
@@ -176,8 +176,8 @@ describe NoticesController do
 
       it "includes any errors in the response" do
         submit_notice = stub_submit_notice
-        submit_notice.stub(:submit).and_return(false)
-        submit_notice.stub(:errors).and_return(
+        allow(submit_notice).to receive(:submit).and_return(false)
+        allow(submit_notice).to receive(:errors).and_return(
           mock_errors(submit_notice.notice, works: "can't be blank")
         )
 
@@ -192,8 +192,8 @@ describe NoticesController do
 
     def stub_submit_notice
       SubmitNotice.new(DMCA, {}).tap do |submit_notice|
-        submit_notice.stub(:submit).and_return(true)
-        SubmitNotice.stub(:new).and_return(submit_notice)
+        allow(submit_notice).to receive(:submit).and_return(true)
+        allow(SubmitNotice).to receive(:new).and_return(submit_notice)
       end
     end
 

--- a/spec/controllers/original_files_controller_spec.rb
+++ b/spec/controllers/original_files_controller_spec.rb
@@ -10,8 +10,8 @@ describe OriginalFilesController do
     end
 
     it "returns http success" do
-      File.stub(:file?).and_return(:true)
-      File.stub(:read).and_return('Content!')
+      allow(File).to receive(:file?).and_return(:true)
+      allow(File).to receive(:read).and_return('Content!')
       expect(response).to be_success
     end
   end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -4,7 +4,7 @@ describe TopicsController do
   context "#show" do
     it "loads the topic by ID" do
       topic = double("Topic").as_null_object
-      Topic.should_receive(:find).with('42').and_return(topic)
+      expect(Topic).to receive(:find).with('42').and_return(topic)
 
       get :show, id: 42
 
@@ -15,11 +15,11 @@ describe TopicsController do
 
     it "uses SearchesModels to find recent notices" do
       topic = double("Topic")
-      topic.stub(:name).and_return('A topic name')
-      Topic.stub(:find).and_return(topic)
+      allow(topic).to receive(:name).and_return('A topic name')
+      allow(Topic).to receive(:find).and_return(topic)
 
       searcher = SearchesModels.new
-      SearchesModels.should_receive(:new).with(
+      expect(SearchesModels).to receive(:new).with(
         { topic: topic.name }).and_return(searcher)
 
       get :show, id: 42
@@ -37,7 +37,7 @@ describe TopicsController do
   context "#index as json" do
     it "loads all topics" do
       topic_list = build_list(:topic, 10)
-      Topic.should_receive(:all)
+      expect(Topic).to receive(:all)
 
       get :index, format: :json
 

--- a/spec/integration/imports_existing_data_as_csv_spec.rb
+++ b/spec/integration/imports_existing_data_as_csv_spec.rb
@@ -44,7 +44,7 @@ feature "Importing CSV" do
 https://www.youtube.com/watch?v=w2-DjJ
 https://www.youtube.com/watch?v=PlsCEe|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 10078
     end
@@ -66,7 +66,7 @@ https://www.youtube.com/watch?v=PlsCEe|
       expect(notice.infringing_urls.map(&:url)).to match_array(
         %w|http://www.youtube.com/watch?v=H0r8U-|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 1007
       expect(notice.mark_registration_number).to eq '12200000'
@@ -89,7 +89,7 @@ https://www.youtube.com/watch?v=PlsCEe|
       expect(notice.infringing_urls.map(&:url)).to match_array(
         %w|https://www.youtube.com/user/ThisChipmunks|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 1006
       expect(notice.mark_registration_number).to eq '29350000'
@@ -114,7 +114,7 @@ https://www.youtube.com/watch?v=PlsCEe|
        http://www.youtube.com/watch?v=6HG
        http://www.youtube.com/watch?v=FzH|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 1005
       expect(notice.mark_registration_number).to eq '28950000'
@@ -137,7 +137,7 @@ https://www.youtube.com/watch?v=PlsCEe|
       expect(notice.infringing_urls.map(&:url)).to match_array(
         %w|https://www.youtube.com/watch?v=7uC2cJz0 https://www.youtube.com/watch?v=lRu8rSY|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 2000
     end
@@ -164,14 +164,14 @@ https://www.youtube.com/watch?v=PlsCEe|
           "http://infringing.example.com/url_second_1"
         ]
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.topics.pluck(:name)).to include('Foobar')
       expect(upload_contents(notice.original_documents.first)).to eq File.read(
         'spec/support/example_files/original_notice_source.txt'
       )
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 1000
-      expect(notice).to have(1).supporting_document
+      expect(notice.size).to eq(1)
       expect(upload_contents(notice.supporting_documents.first)).to eq File.read(
         'spec/support/example_files/original.jpg'
       )
@@ -197,14 +197,14 @@ https://www.youtube.com/watch?v=PlsCEe|
 http://www.example.com/unstoppable_2.html
 http://www.example.com/unstoppable_3.html|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.topics.pluck(:name)).to include('Foobar')
       expect(upload_contents(notice.original_documents.first)).to eq File.read(
         'spec/support/example_files/secondary_dmca_notice_source.html'
       )
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 1001
-      expect(notice).to have(1).supporting_document
+      expect(notice.size).to eq(1)
       expect(upload_contents(notice.supporting_documents.first)).to eq File.read(
         'spec/support/example_files/secondary_dmca_notice_source-2.html'
       )
@@ -221,14 +221,14 @@ http://www.example.com/unstoppable_3.html|
         %w|http://www.example.com/asdfasdf
         http://www.example.com/infringing|
       )
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.topics.pluck(:name)).to include('Foobar')
       expect(upload_contents(notice.original_documents.first)).to eq File.read(
         'spec/support/example_files/secondary_other_notice_source.html'
       )
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to eq 1002
-      expect(notice).to have(1).supporting_document
+      expect(notice.size).to eq(1)
       expect(upload_contents(notice.supporting_documents.first)).to eq File.read(
         'spec/support/example_files/secondary_other_notice_source-2.html'
       )
@@ -245,14 +245,14 @@ http://www.example.com/unstoppable_3.html|
         'https://twitter.com/NoMatter/status/12345',
         'https://twitter.com/NoMatter/status/4567',
       ])
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.topics.pluck(:name)).to include('Foobar')
       expect(upload_contents(notice.original_documents.first)).to eq File.read(
         'spec/support/example_files/original_twitter_notice_source.txt'
       )
       expect(notice.action_taken).to eq ''
       expect(notice.submission_id).to be_nil
-      expect(notice).to have(1).supporting_document
+      expect(notice.size).to eq(1)
       expect(upload_contents(notice.supporting_documents.first)).to eq File.read(
         'spec/support/example_files/original_twitter_notice_source.html'
       )
@@ -265,7 +265,7 @@ http://www.example.com/unstoppable_3.html|
     scenario "a notice is created and entity info is recovered from the file" do
       expect(notice.title).to eq 'Untitled'
       expect(notice.works.length).to eq 2
-      expect(notice).to have(1).original_document
+      expect(notice.size).to eq(1)
       expect(notice.entities.map(&:name)).to match_array(
         ["Copyright Owner LLC", "Google, Inc.", "Joe Schmoe"]
       )

--- a/spec/lib/blog_importer_spec.rb
+++ b/spec/lib/blog_importer_spec.rb
@@ -4,11 +4,11 @@ require 'blog_importer'
 describe BlogImporter do
 
   it "converts HTML to markdown via Html2Md " do
-    BlogEntry.stub(:create!).and_return(BlogEntry.new)
+    allow(BlogEntry).to receive(:create!).and_return(BlogEntry.new)
     blog_entry = attributes_for(:blog_entry, :with_abstract, :with_content)
 
     html2md = Html2Md.new('bupkis')
-    Html2Md.should_receive(:new).twice.and_return(html2md)
+    expect(Html2Md).to receive(:new).twice.and_return(html2md)
 
     with_csv_file_for(blog_entry) do |csv_file|
       importer = described_class.new(csv_file.path)

--- a/spec/lib/ingestor/importer/google/field_group_parser_spec.rb
+++ b/spec/lib/ingestor/importer/google/field_group_parser_spec.rb
@@ -30,7 +30,7 @@ Track Name: Flipy The Bear")
 
   def parser
     described_class.new(
-      stub("FieldGroup", key: 0, content: field_group_content)
+      double("FieldGroup", key: 0, content: field_group_content)
     )
   end
 

--- a/spec/lib/ingestor/importer/google_spec.rb
+++ b/spec/lib/ingestor/importer/google_spec.rb
@@ -11,11 +11,11 @@ describe Ingestor::Importer::Google do
     it "should not inspect binary files" do
       file_double = double('File handle')
 
-      File.stub(:open) do |&block|
+      allow(File).to receive(:open) do |&block|
         block.yield file_double
       end
 
-      file_double.should_not_receive(:grep)
+      expect(file_double).not_to receive(:grep)
       described_class.handles?('spec/support/example_files/original.jpg')
     end
   end

--- a/spec/lib/ingestor/legacy/attribute_mapper_spec.rb
+++ b/spec/lib/ingestor/legacy/attribute_mapper_spec.rb
@@ -5,8 +5,8 @@ describe Ingestor::Legacy::AttributeMapper do
   context "#notice_type" do
     it "returns the notice_type of its importer" do
       importer = double("Importer")
-      importer.stub(:notice_type).and_return(Trademark)
-      Ingestor::ImportDispatcher.stub(:for).and_return(importer)
+      allow(importer).to receive(:notice_type).and_return(Trademark)
+      allow(Ingestor::ImportDispatcher).to receive(:for).and_return(importer)
 
       mapper = described_class.new({})
 
@@ -109,8 +109,8 @@ describe Ingestor::Legacy::AttributeMapper do
         'OriginalFilePath' => 'path',
         'SupportingFilePath' => 'other path'
       }
-      Ingestor::ImportDispatcher.
-        should_receive(:for).with('path', 'other path').and_return(@import_class)
+      expect(Ingestor::ImportDispatcher).
+        to receive(:for).with('path', 'other path').and_return(@import_class)
 
       attributes = described_class.new(hash).mapped
 
@@ -120,7 +120,7 @@ describe Ingestor::Legacy::AttributeMapper do
     end
 
     it "does pass through the Body value" do
-      Ingestor::ImportDispatcher.should_receive(:for).and_return(@import_class)
+      expect(Ingestor::ImportDispatcher).to receive(:for).and_return(@import_class)
 
       attributes = described_class.new({ 'Body' => 'foobar' }).mapped
 
@@ -325,8 +325,8 @@ contact_email_noprefill: info.antipiracy@dtecnet.com|,
       sender_address: nil,
       recipient: nil
     )
-    Ingestor::ImportDispatcher.stub(:for).and_return(import_class)
-    import_class.should_receive(:entities).exactly(4).times
+    allow(Ingestor::ImportDispatcher).to receive(:for).and_return(import_class)
+    expect(import_class).to receive(:entities).exactly(4).times
 
     attributes = described_class.new({}).mapped
     entity = find_entity_notice_role(attributes, 'sender').entity
@@ -452,7 +452,7 @@ contact_email_noprefill: info.antipiracy@dtecnet.com|,
       sender_address: nil,
       recipient: nil
     }
-    Ingestor::ImportDispatcher.stub(:for).and_return(double(
+    allow(Ingestor::ImportDispatcher).to receive(:for).and_return(double(
       "ImportClass", stubbed_methods
     ))
   end

--- a/spec/lib/ingestor/legacy/error_handler_spec.rb
+++ b/spec/lib/ingestor/legacy/error_handler_spec.rb
@@ -26,14 +26,14 @@ describe Ingestor::Legacy::ErrorHandler do
     end
 
     it "outputs the failure via its logger" do
-      Rails.logger.should_receive(:error).with('legacy import error original_notice_id: 1000, name: tNotice.csv, message: "(RuntimeError) Boom!: first"')
+      expect(Rails.logger).to receive(:error).with('legacy import error original_notice_id: 1000, name: tNotice.csv, message: "(RuntimeError) Boom!: first"')
       handler = described_class.new('tNotice.csv')
 
       handler.handle(csv_row, exception)
     end
 
     it "creates a relevant ImportError model instance" do
-      NoticeImportError.should_receive(:create!).with(
+      expect(NoticeImportError).to receive(:create!).with(
         original_notice_id: 1000,
         file_list: 'sub/original.txt,sub/original.html',
         message: 'Boom!',
@@ -56,7 +56,7 @@ describe Ingestor::Legacy::ErrorHandler do
 
     def exception
       RuntimeError.new("Boom!").tap do |ex|
-        ex.stub(:backtrace).and_return(%w( first second third ))
+        allow(ex).to receive(:backtrace).and_return(%w( first second third ))
       end
     end
   end

--- a/spec/lib/ingestor/legacy/record_source/file_path_correcter_spec.rb
+++ b/spec/lib/ingestor/legacy/record_source/file_path_correcter_spec.rb
@@ -14,7 +14,7 @@ describe Ingestor::Legacy::RecordSource::FilePathCorrector do
 
   it "calculates paths properly" do
     Dir.chdir(test_directory) do
-      File.stub(:exists?).and_return(:true)
+      allow(File).to receive(:exists?).and_return(:true)
       corrected_paths = described_class.correct_paths(
         'foo.txt,bar.html,files_by_time/4444/22/22/22/baz.html,sub/bat.html'
       )

--- a/spec/lib/ingestor/legacy/record_source/mysql_spec.rb
+++ b/spec/lib/ingestor/legacy/record_source/mysql_spec.rb
@@ -30,11 +30,11 @@ describe Ingestor::Legacy::RecordSource::Mysql do
 
   def mysql_record_source
     connection_double = double("Mysql connection")
-    connection_double.stub(:query).and_return([
+    allow(connection_double).to receive(:query).and_return([
       'foo' => 1, 'bar' => 2, 'OriginalFilePath' => 'foo.html',
       'SupportingFilePath' => 'bar.html']
     )
-    Mysql2::Client.stub(:new).and_return(connection_double)
+    allow(Mysql2::Client).to receive(:new).and_return(connection_double)
 
     described_class.new('select * from tNotice', 'test_records')
   end

--- a/spec/lib/ingestor/legacy_spec.rb
+++ b/spec/lib/ingestor/legacy_spec.rb
@@ -5,18 +5,18 @@ describe Ingestor::Legacy do
 
   before do
     @error_handler = double.as_null_object
-    described_class::ErrorHandler.stub(:new).and_return(@error_handler)
+    allow(described_class::ErrorHandler).to receive(:new).and_return(@error_handler)
 
     @attribute_mapper = double("AttributeMapper")
-    @attribute_mapper.stub(:exclude?).and_return(false)
-    @attribute_mapper.stub(:notice_type).and_return(DMCA)
-    @attribute_mapper.stub(:mapped).and_return({})
-    described_class::AttributeMapper.stub(:new).and_return(@attribute_mapper)
+    allow(@attribute_mapper).to receive(:exclude?).and_return(false)
+    allow(@attribute_mapper).to receive(:notice_type).and_return(DMCA)
+    allow(@attribute_mapper).to receive(:mapped).and_return({})
+    allow(described_class::AttributeMapper).to receive(:new).and_return(@attribute_mapper)
   end
 
   it "instantiates the correct notice type based on AttributeMapper" do
-    @attribute_mapper.stub(:notice_type).and_return(Trademark)
-    Trademark.should_receive(:create!).at_least(:once).and_return(Trademark.new)
+    allow(@attribute_mapper).to receive(:notice_type).and_return(Trademark)
+    expect(Trademark).to receive(:create!).at_least(:once).and_return(Trademark.new)
 
     importer.import
   end
@@ -25,10 +25,10 @@ describe Ingestor::Legacy do
     dmca = DMCA.new
 
     existing_notice_ids.each do |original_notice_id|
-      Notice.should_receive(:where).with(original_notice_id: original_notice_id).once.and_return(dmca)
+      expect(Notice).to receive(:where).with(original_notice_id: original_notice_id).once.and_return(dmca)
     end
 
-    DMCA.should_not_receive(:create!)
+    expect(DMCA).not_to receive(:create!)
 
     importer.import
   end

--- a/spec/lib/kaminari/active_record_relation_methods_spec.rb
+++ b/spec/lib/kaminari/active_record_relation_methods_spec.rb
@@ -6,7 +6,7 @@ describe 'Customized kaminari counting' do
     dummy = Dummy.new(table_name)
     execute_double = stub_execute(dummy)
 
-    execute_double.should_receive(:execute)
+    expect(execute_double).to receive(:execute)
 
     with_configured_pagination_overrides([ table_name ]) do
       dummy.total_count
@@ -20,7 +20,7 @@ describe 'Customized kaminari counting' do
     dummy = Dummy.new(table_name)
     execute_double = stub_execute(dummy)
 
-    execute_double.should_not_receive(:execute)
+    expect(execute_double).not_to receive(:execute)
 
     with_configured_pagination_overrides([ different_table_name ]) do
       begin
@@ -32,7 +32,7 @@ describe 'Customized kaminari counting' do
 
   def stub_execute(dummy)
     double('Execute double', execute: [{ 'reltuples' => 100 }]).tap do |execute_double|
-      dummy.stub(:connection).and_return(execute_double)
+      allow(dummy).to receive(:connection).and_return(execute_double)
     end
   end
 

--- a/spec/lib/question_importer_spec.rb
+++ b/spec/lib/question_importer_spec.rb
@@ -33,8 +33,8 @@ OriginalNoticeID,Question
 
     notice_1 = Notice.where(original_notice_id: 1).first
     notice_2 = Notice.where(original_notice_id: 2).first
-    expect(notice_1).to have(1).relevant_question
-    expect(notice_2).to have(1).relevant_question
+    expect(notice_1.size).to eq(1)
+    expect(notice_2.size).to eq(1)
   end
 
   it "does not clobber existing relevant questions" do
@@ -46,6 +46,6 @@ OriginalNoticeID,Question
 
     QuestionImporter.new(sample_file).import
 
-    expect(notice.reload).to have(3).relevant_questions
+    expect(notice.reload.size).to eq(3)
   end
 end

--- a/spec/models/blog_entry_spec.rb
+++ b/spec/models/blog_entry_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe BlogEntry, type: :model do
   context "automatic validations" do
-    it { should validate_presence_of(:author) }
-    it { should validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:author) }
+    it { is_expected.to validate_presence_of(:title) }
   end
 
-  it { should belong_to(:user) }
-  it { should have_many(:blog_entry_topic_assignments).dependent(:destroy) }
-  it { should have_many(:topics).through(:blog_entry_topic_assignments) }
-  it { should validate_inclusion_of(:image).in_array BlogEntry.valid_images }
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:blog_entry_topic_assignments).dependent(:destroy) }
+  it { is_expected.to have_many(:topics).through(:blog_entry_topic_assignments) }
+  it { is_expected.to validate_inclusion_of(:image).in_array BlogEntry.valid_images }
 
   it_behaves_like "an object with a recent scope"
 

--- a/spec/models/copyrighted_url_spec.rb
+++ b/spec/models/copyrighted_url_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe CopyrightedUrl, type: :model do
-  it { should_not have_db_index(:url).unique(true) }
-  it { should have_db_index(:url_original).unique(true) }
+  it { is_expected.not_to have_db_index(:url).unique(true) }
+  it { is_expected.to have_db_index(:url_original).unique(true) }
 
   context 'automatic validations' do
-    it { should validate_presence_of(:url_original) }
-    it { should validate_length_of(:url).is_at_most(8.kilobytes) }
-    it { should validate_length_of(:url_original).is_at_most(8.kilobytes) }
+    it { is_expected.to validate_presence_of(:url_original) }
+    it { is_expected.to validate_length_of(:url).is_at_most(8.kilobytes) }
+    it { is_expected.to validate_length_of(:url_original).is_at_most(8.kilobytes) }
   end
 
   context "#url" do

--- a/spec/models/counter_notice_spec.rb
+++ b/spec/models/counter_notice_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe CounterNotice, type: :model do
-  it { should validate_presence_of :attach_list_of_works }
-  it { should validate_presence_of :list_removed_in_error }
-  it { should validate_presence_of :perjury_risk_acknowledged }
-  it { should validate_presence_of :consent_to_be_served }
-  it { should validate_presence_of :jurisdiction }
+  it { is_expected.to validate_presence_of :attach_list_of_works }
+  it { is_expected.to validate_presence_of :list_removed_in_error }
+  it { is_expected.to validate_presence_of :perjury_risk_acknowledged }
+  it { is_expected.to validate_presence_of :consent_to_be_served }
+  it { is_expected.to validate_presence_of :jurisdiction }
 
   context "jurisdictions" do
     it "knows when it's in the US" do

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -5,23 +5,23 @@ describe DMCA, type: :model do
     @notice_topics = create_list(:notice_topic, 8)
   end
 
-  it { should validate_presence_of :works }
-  it { should validate_presence_of :entity_notice_roles }
-  it { should validate_inclusion_of(:language).in_array(Language.codes) }
-  it { should validate_inclusion_of(:action_taken).in_array(DMCA::VALID_ACTIONS).allow_blank }
+  it { is_expected.to validate_presence_of :works }
+  it { is_expected.to validate_presence_of :entity_notice_roles }
+  it { is_expected.to validate_inclusion_of(:language).in_array(Language.codes) }
+  it { is_expected.to validate_inclusion_of(:action_taken).in_array(DMCA::VALID_ACTIONS).allow_blank }
 
   context 'automatic validations' do
-    it { should validate_length_of(:title).is_at_most(255) }
+    it { is_expected.to validate_length_of(:title).is_at_most(255) }
   end
 
-  it { should have_many :file_uploads }
-  it { should have_many(:entity_notice_roles).dependent(:destroy) }
-  it { should have_and_belong_to_many :works }
-  it { should have_many(:infringing_urls).through(:works) }
-  it { should have_many(:entities).through(:entity_notice_roles)  }
-  it { should have_many(:topic_assignments).dependent(:destroy) }
-  it { should have_many(:topics).through(:topic_assignments) }
-  it { should have_and_belong_to_many :relevant_questions }
+  it { is_expected.to have_many :file_uploads }
+  it { is_expected.to have_many(:entity_notice_roles).dependent(:destroy) }
+  it { is_expected.to have_and_belong_to_many :works }
+  it { is_expected.to have_many(:infringing_urls).through(:works) }
+  it { is_expected.to have_many(:entities).through(:entity_notice_roles)  }
+  it { is_expected.to have_many(:topic_assignments).dependent(:destroy) }
+  it { is_expected.to have_many(:topics).through(:topic_assignments) }
+  it { is_expected.to have_and_belong_to_many :relevant_questions }
 
   it_behaves_like "an object with a recent scope"
   it_behaves_like "an object tagged in the context of", "tag", case_insensitive: true
@@ -205,8 +205,8 @@ describe DMCA, type: :model do
     it "calls RedactsNotices#redact on itself" do
       notice = DMCA.new
       redactor = RedactsNotices.new
-      redactor.should_receive(:redact).with(notice)
-      RedactsNotices.should_receive(:new).and_return(redactor)
+      expect(redactor).to receive(:redact).with(notice)
+      expect(RedactsNotices).to receive(:new).and_return(redactor)
 
       notice.auto_redact
     end
@@ -216,8 +216,8 @@ describe DMCA, type: :model do
     it 'copies id to submission_id' do
       id_value = 100
       notice = build(:dmca)
-      notice.should_receive(:id).and_return(id_value)
-      notice.should_receive(:update_column).with(:submission_id, id_value)
+      expect(notice).to receive(:id).and_return(id_value)
+      expect(notice).to receive(:update_column).with(:submission_id, id_value)
 
       notice.copy_id_to_submission_id
     end
@@ -244,9 +244,9 @@ describe DMCA, type: :model do
 
     def mock_assessment(notice, high_risk)
       assessment = RiskAssessment.new(notice)
-      assessment.stub(:high_risk?).and_return(high_risk)
+      allow(assessment).to receive(:high_risk?).and_return(high_risk)
 
-      RiskAssessment.should_receive(:new).with(notice).and_return(assessment)
+      expect(RiskAssessment).to receive(:new).with(notice).and_return(assessment)
     end
   end
 
@@ -343,7 +343,7 @@ describe DMCA, type: :model do
 
       notice = create(:dmca, file_uploads: file_uploads)
 
-      expect(notice).to have(2).supporting_documents
+      expect(notice.size).to eq(2)
       expect(notice.supporting_documents).to be_all { |d| d.kind == 'supporting' }
     end
   end
@@ -358,7 +358,7 @@ describe DMCA, type: :model do
 
       notice = create(:dmca, file_uploads: file_uploads)
 
-      expect(notice).to have(2).original_documents
+      expect(notice.size).to eq(2)
       expect(notice.original_documents).to be_all { |d| d.kind == 'original' }
     end
   end

--- a/spec/models/entity_notice_role_spec.rb
+++ b/spec/models/entity_notice_role_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe EntityNoticeRole, type: :model do
-  it { should belong_to :entity }
-  it { should belong_to :notice }
+  it { is_expected.to belong_to :entity }
+  it { is_expected.to belong_to :notice }
 
   context 'automatic validations' do
-    it { should validate_presence_of :name }
-    it { should validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
   end
 
-  it { should validate_presence_of :entity }
-  it { should validate_presence_of :notice }
+  it { is_expected.to validate_presence_of :entity }
+  it { is_expected.to validate_presence_of :notice }
 
-  it { should have_db_index :entity_id }
-  it { should have_db_index :notice_id }
-  it { should validate_inclusion_of(:name).in_array(EntityNoticeRole::ROLES) }
+  it { is_expected.to have_db_index :entity_id }
+  it { is_expected.to have_db_index :notice_id }
+  it { is_expected.to validate_inclusion_of(:name).in_array(EntityNoticeRole::ROLES) }
 
   EntityNoticeRole::ROLES.each do |role|
     context "getting #{role} instances" do

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe Entity, type: :model do
   context 'automatic validations' do
-    it { should validate_presence_of :name }
-    it { should validate_presence_of :kind }
-    it { should validate_length_of(:address_line_1).is_at_most(255) }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :kind }
+    it { is_expected.to validate_length_of(:address_line_1).is_at_most(255) }
   end
 
   context 'de-duplication' do
@@ -27,10 +27,10 @@ describe Entity, type: :model do
     end
   end
 
-  it { should belong_to(:user) }
-  it { should have_many(:entity_notice_roles).dependent(:destroy) }
-  it { should have_many(:notices).through(:entity_notice_roles)  }
-  it { should validate_inclusion_of(:kind).in_array(Entity::KINDS) }
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:entity_notice_roles).dependent(:destroy) }
+  it { is_expected.to have_many(:notices).through(:entity_notice_roles)  }
+  it { is_expected.to validate_inclusion_of(:kind).in_array(Entity::KINDS) }
 
   context ".submitters" do
     it "returns only submitter types" do
@@ -50,7 +50,7 @@ describe Entity, type: :model do
   context 'post update reindexing' do
     it "uses the TopicIndexQueuer to schedule notices for indexing" do
       entity = create(:entity)
-      EntityIndexQueuer.should_receive(:for).with(entity.id)
+      expect(EntityIndexQueuer).to receive(:for).with(entity.id)
 
       entity.save
     end

--- a/spec/models/file_upload_spec.rb
+++ b/spec/models/file_upload_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe FileUpload, type: :model do
-  it { should have_attached_file(:file) }
-  it { should belong_to :notice }
-  it { should have_db_index :notice_id }
-  it { should validate_inclusion_of(:kind).in_array %w( original supporting ) }
+  it { is_expected.to have_attached_file(:file) }
+  it { is_expected.to belong_to :notice }
+  it { is_expected.to have_db_index :notice_id }
+  it { is_expected.to validate_inclusion_of(:kind).in_array %w( original supporting ) }
 
   context 'automatic validations' do
-    it { should validate_length_of(:kind).is_at_most(255) }
+    it { is_expected.to validate_length_of(:kind).is_at_most(255) }
   end
 
   context "file_type" do

--- a/spec/models/infringing_url_spec.rb
+++ b/spec/models/infringing_url_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe InfringingUrl, type: :model do
-  it { should_not have_db_index(:url).unique(true) }
-  it { should have_db_index(:url_original).unique(true) }
+  it { is_expected.not_to have_db_index(:url).unique(true) }
+  it { is_expected.to have_db_index(:url_original).unique(true) }
 
   context 'automatic validations' do
-    it { should validate_presence_of(:url_original) }
-    it { should validate_length_of(:url).is_at_most(8.kilobytes) }
-    it { should validate_length_of(:url_original).is_at_most(8.kilobytes) }
+    it { is_expected.to validate_presence_of(:url_original) }
+    it { is_expected.to validate_length_of(:url).is_at_most(8.kilobytes) }
+    it { is_expected.to validate_length_of(:url_original).is_at_most(8.kilobytes) }
   end
 
   context "#url" do

--- a/spec/models/law_enforcement_request_spec.rb
+++ b/spec/models/law_enforcement_request_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe LawEnforcementRequest, type: :model do
-  it { should validate_inclusion_of(:request_type).
+  it { is_expected.to validate_inclusion_of(:request_type).
     in_array(described_class::VALID_REQUEST_TYPES).allow_blank(true) }
 
   it "has additional entities" do

--- a/spec/models/notice_import_error_spec.rb
+++ b/spec/models/notice_import_error_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe NoticeImportError, type: :model do
-  it { should validate_length_of(:file_list).is_at_most(2.kilobytes) }
-  it { should validate_length_of(:message).is_at_most(16.kilobytes) }
-  it { should validate_length_of(:stacktrace).is_at_most(2.kilobytes) }
-  it { should validate_length_of(:import_set_name).is_at_most(1.kilobyte) }
+  it { is_expected.to validate_length_of(:file_list).is_at_most(2.kilobytes) }
+  it { is_expected.to validate_length_of(:message).is_at_most(16.kilobytes) }
+  it { is_expected.to validate_length_of(:stacktrace).is_at_most(2.kilobytes) }
+  it { is_expected.to validate_length_of(:import_set_name).is_at_most(1.kilobyte) }
 end

--- a/spec/models/notice_serializer_proxy_spec.rb
+++ b/spec/models/notice_serializer_proxy_spec.rb
@@ -5,8 +5,8 @@ describe NoticeSerializerProxy, type: :model do
   it "uses the instance's serializer when present" do
     trademark = build_stubbed(:trademark)
     serialized = TrademarkSerializer.new(trademark)
-    serialized.stub(:a_method).and_return(:a_value) # test delegation
-    TrademarkSerializer.should_receive(:new).with(trademark).and_return(serialized)
+    allow(serialized).to receive(:a_method).and_return(:a_value) # test delegation
+    expect(TrademarkSerializer).to receive(:new).with(trademark).and_return(serialized)
 
     delegator = NoticeSerializerProxy.new(trademark)
 
@@ -16,8 +16,8 @@ describe NoticeSerializerProxy, type: :model do
   it "uses NoticeSerializer when no custom serializer is present" do
     object = double('Instance', active_model_serializer: nil)
     serialized = NoticeSerializer.new(object)
-    serialized.stub(:a_method).and_return(:a_value) # test delegation
-    NoticeSerializer.should_receive(:new).with(object).and_return(serialized)
+    allow(serialized).to receive(:a_method).and_return(:a_value) # test delegation
+    expect(NoticeSerializer).to receive(:new).with(object).and_return(serialized)
 
     delegator = NoticeSerializerProxy.new(object)
 

--- a/spec/models/redaction/queue_spec.rb
+++ b/spec/models/redaction/queue_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Redaction::Queue do
   FAKE_QUEUE_MAX = 2
 
-  before { Redaction::Queue.stub(:queue_max).and_return(FAKE_QUEUE_MAX) }
+  before { allow(Redaction::Queue).to receive(:queue_max).and_return(FAKE_QUEUE_MAX) }
 
   context '#notices' do
     it "returns the notices in review with the user" do
       user = User.new
-      Notice.should_receive(:in_review).with(user).and_return(:some_notices)
+      expect(Notice).to receive(:in_review).with(user).and_return(:some_notices)
 
       queue = new_queue(user)
 
@@ -174,7 +174,7 @@ describe Redaction::Queue do
 
   def stub_notices_in_review(n)
     notices = Array.new(n) { Notice.new }
-    Notice.stub(:in_review).and_return(notices)
+    allow(Notice).to receive(:in_review).and_return(notices)
   end
 
   def new_queue(user = User.new)

--- a/spec/models/redacts_notices_spec.rb
+++ b/spec/models/redacts_notices_spec.rb
@@ -143,7 +143,7 @@ describe RedactsNotices do
 
   def simple_redactor(from, to)
     redactor = RedactsNotices::RedactsContent.new(from)
-    redactor.stub(:mask).and_return(to)
+    allow(redactor).to receive(:mask).and_return(to)
 
     redactor
   end

--- a/spec/models/reindex_run_spec.rb
+++ b/spec/models/reindex_run_spec.rb
@@ -4,19 +4,19 @@ describe ReindexRun, type: :model do
 
   it "tracks run information when no exceptions are thrown" do
     reindex_run = build(:reindex_run)
-    ReindexRun.should_receive(:create!).and_return(reindex_run)
+    expect(ReindexRun).to receive(:create!).and_return(reindex_run)
     now = Time.now
-    Time.stub(:now).and_return(now)
+    allow(Time).to receive(:now).and_return(now)
 
-    reindex_run.should_receive(:update_attributes).with(
+    expect(reindex_run).to receive(:update_attributes).with(
       notice_count: 0, entity_count: 0, updated_at: now
     )
     described_class.index_changed_model_instances
   end
 
   it "does not track run information when exceptions are thrown" do
-    ReindexRun.should_not_receive(:create!).with(entity_count: 0, notice_count: 0)
-    Notice.stub(:where).and_raise(StandardError)
+    expect(ReindexRun).not_to receive(:create!).with(entity_count: 0, notice_count: 0)
+    allow(Notice).to receive(:where).and_raise(StandardError)
 
     described_class.index_changed_model_instances
   end
@@ -37,7 +37,7 @@ describe ReindexRun, type: :model do
       old_entity = Timecop.travel(1.hour.ago) { create(:entity, name: 'Old') }
       new_entity = Timecop.travel(1.hour) { create(:entity, name: 'New') }
 
-      Entity.any_instance.should_receive(:tire).once.and_return(tire_proxy)
+      expect_any_instance_of(Entity).to receive(:tire).once.and_return(tire_proxy)
 
       described_class.index_changed_model_instances
     end
@@ -50,7 +50,7 @@ describe ReindexRun, type: :model do
       old_entity = Timecop.travel(1.hour.ago) { create(:dmca, title: 'Old') }
       new_entity = Timecop.travel(1.hour) { create(:dmca, title: 'New') }
 
-      Notice.any_instance.should_receive(:tire).once.and_return(tire_proxy)
+      expect_any_instance_of(Notice).to receive(:tire).once.and_return(tire_proxy)
 
       described_class.index_changed_model_instances
     end

--- a/spec/models/relevant_question_spec.rb
+++ b/spec/models/relevant_question_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe RelevantQuestion, type: :model do
   context 'automatic validations' do
-    it { should validate_presence_of(:question) }
-    it { should validate_presence_of(:answer) }
+    it { is_expected.to validate_presence_of(:question) }
+    it { is_expected.to validate_presence_of(:answer) }
   end
 
   context "#answer_html" do

--- a/spec/models/risk_assessment_spec.rb
+++ b/spec/models/risk_assessment_spec.rb
@@ -7,11 +7,11 @@ describe RiskAssessment, type: :model do
       trigger_2 = double("Trigger 2"),
       trigger_3 = double("Trigger 3")
     ]
-    RiskTrigger.stub(:all).and_return(triggers)
+    allow(RiskTrigger).to receive(:all).and_return(triggers)
     notice = double("Notice")
-    trigger_1.should_receive(:risky?).with(notice).and_return(false)
-    trigger_2.should_receive(:risky?).with(notice).and_return(true)
-    trigger_3.should_not_receive(:risky?) # enforce short-circuit logic
+    expect(trigger_1).to receive(:risky?).with(notice).and_return(false)
+    expect(trigger_2).to receive(:risky?).with(notice).and_return(true)
+    expect(trigger_3).not_to receive(:risky?) # enforce short-circuit logic
 
     assessment = RiskAssessment.new(notice)
 
@@ -19,7 +19,7 @@ describe RiskAssessment, type: :model do
   end
 
   it "returns false if no trigger triggers" do
-    RiskTrigger.stub(:all).and_return([
+    allow(RiskTrigger).to receive(:all).and_return([
       double("Trigger 1", risky?: false),
       double("Trigger 2", risky?: false),
       double("Trigger 3", risky?: false)

--- a/spec/models/search_results_proxy_spec.rb
+++ b/spec/models/search_results_proxy_spec.rb
@@ -5,9 +5,9 @@ describe SearchResultsProxy, type: :model do
     notice = build_stubbed(:dmca)
     attributes = with_metadata(notice).merge('class_name' => 'notice')
     new_notice = Notice.new
-    Notice.stub(:new).and_return(new_notice)
+    allow(Notice).to receive(:new).and_return(new_notice)
 
-    NoticeSearchResult.should_receive(:new).with(new_notice, attributes)
+    expect(NoticeSearchResult).to receive(:new).with(new_notice, attributes)
 
     described_class.new(attributes)
   end
@@ -15,7 +15,7 @@ describe SearchResultsProxy, type: :model do
   it 'proxies to the default wrapper' do
     entity = build_stubbed(:entity)
 
-    Tire::Results::Item.should_receive(:new).with(entity.attributes)
+    expect(Tire::Results::Item).to receive(:new).with(entity.attributes)
 
     router = described_class.new(entity.attributes)
   end

--- a/spec/models/searches_models_spec.rb
+++ b/spec/models/searches_models_spec.rb
@@ -4,7 +4,7 @@ describe SearchesModels, type: :model do
   context 'visible_qualifiers' do
     it "delegates to the @model_class" do
       expected = { expected_key: :expected_value }
-      FakeModel.stub(:visible_qualifiers).and_return(expected)
+      allow(FakeModel).to receive(:visible_qualifiers).and_return(expected)
       expect(described_class.new({}, FakeModel).visible_qualifiers).to eq(expected)
     end
 
@@ -23,7 +23,7 @@ describe SearchesModels, type: :model do
   end
 
   it "finds the index_name from the model_class" do
-    FakeModel.should_receive(:index_name)
+    expect(FakeModel).to receive(:index_name)
 
     searcher = described_class.new({foo: 'bar'}, FakeModel)
     searcher.search
@@ -48,7 +48,7 @@ describe SearchesModels, type: :model do
       searcher = described_class.new(params_hash)
       searcher.register filter
 
-      filter.should_receive(:filter_for).with(params_hash[:title]).and_return(
+      expect(filter).to receive(:filter_for).with(params_hash[:title]).and_return(
         [ bleep: { foo: ['as'] } ]
       )
       searcher.search
@@ -57,7 +57,7 @@ describe SearchesModels, type: :model do
 
   context '.cache_key' do
     it "uses md5 hashing for uniqueness" do
-      Digest::MD5.should_receive(:hexdigest)
+      expect(Digest::MD5).to receive(:hexdigest)
       searcher = described_class.new
       searcher.cache_key
     end
@@ -76,7 +76,7 @@ describe SearchesModels, type: :model do
       searcher = described_class.new(params_hash)
       searcher.register all_fields
 
-      all_fields.should_receive(:query_for).with(params_hash[:term], nil)
+      expect(all_fields).to receive(:query_for).with(params_hash[:term], nil)
 
       searcher.search
     end
@@ -87,7 +87,7 @@ describe SearchesModels, type: :model do
       searcher = described_class.new(modified_params_hash)
       searcher.register all_fields
 
-      all_fields.should_receive(:query_for).with(params_hash[:term], 'AND')
+      expect(all_fields).to receive(:query_for).with(params_hash[:term], 'AND')
       searcher.search
     end
   end

--- a/spec/models/submit_notice_spec.rb
+++ b/spec/models/submit_notice_spec.rb
@@ -4,7 +4,7 @@ describe SubmitNotice, type: :model do
   context "#notice" do
     it "returns a memoized instance" do
       notice = DMCA.new
-      DMCA.should_receive(:new).once.
+      expect(DMCA).to receive(:new).once.
         with(attribute: 'value').and_return(notice)
 
       submit_notice = SubmitNotice.new(DMCA, attribute: 'value')
@@ -17,7 +17,7 @@ describe SubmitNotice, type: :model do
   context "#errors" do
     it "delegates to #notice" do
       notice = stub_new(DMCA)
-      notice.stub(:errors).and_return(:arbitrary)
+      allow(notice).to receive(:errors).and_return(:arbitrary)
       submit_notice = SubmitNotice.new(DMCA, {})
 
       expect(submit_notice.errors).to eq :arbitrary
@@ -90,16 +90,16 @@ describe SubmitNotice, type: :model do
 
     it "auto redacts always" do
       notice = stub_new(DMCA)
-      notice.should_receive(:auto_redact)
+      expect(notice).to receive(:auto_redact)
 
       SubmitNotice.new(DMCA, {}).submit
     end
 
     it "returns true and marks for review success" do
       notice = stub_new(DMCA)
-      notice.stub(:save).and_return(true)
-      notice.stub(:copy_id_to_submission_id)
-      notice.should_receive(:mark_for_review)
+      allow(notice).to receive(:save).and_return(true)
+      allow(notice).to receive(:copy_id_to_submission_id)
+      expect(notice).to receive(:mark_for_review)
 
       ret = SubmitNotice.new(DMCA, {}).submit
 
@@ -108,16 +108,16 @@ describe SubmitNotice, type: :model do
 
     it 'copies id to submission_id' do
       notice = stub_new(DMCA)
-      notice.stub(:save).and_return(true)
-      notice.stub(:mark_for_review)
-      notice.should_receive(:copy_id_to_submission_id)
+      allow(notice).to receive(:save).and_return(true)
+      allow(notice).to receive(:mark_for_review)
+      expect(notice).to receive(:copy_id_to_submission_id)
 
       SubmitNotice.new(DMCA, {}).submit
     end
 
     it "returns false on failure" do
       notice = stub_new(DMCA)
-      notice.stub(:save).and_return(false)
+      allow(notice).to receive(:save).and_return(false)
 
       ret = SubmitNotice.new(DMCA, {}).submit
 
@@ -128,14 +128,14 @@ describe SubmitNotice, type: :model do
 
   context "#submit for a user" do
     it "does nothing if the user has no entity" do
-      DMCA.should_receive(:new).with(title: "A title").and_return(null_object)
+      expect(DMCA).to receive(:new).with(title: "A title").and_return(null_object)
 
       SubmitNotice.new(DMCA, title: "A title").submit(User.new)
     end
 
     it "adds entity attributes when user has an entity" do
       user = build(:user, :with_entity)
-      DMCA.should_receive(:new).with(
+      expect(DMCA).to receive(:new).with(
         title: "A title",
         entity_notice_roles_attributes: [
           { name: 'submitter', entity_id: user.entity.id },
@@ -148,7 +148,7 @@ describe SubmitNotice, type: :model do
 
     it "does not affect other roles" do
       user = build(:user, :with_entity)
-      DMCA.should_receive(:new).with(
+      expect(DMCA).to receive(:new).with(
         entity_notice_roles_attributes: [
           { name: 'sender', entity_attributes: { name: 'Sender' } },
           { name: 'submitter', entity_id: user.entity.id },
@@ -163,7 +163,7 @@ describe SubmitNotice, type: :model do
 
     it "does not override an explicitly submitted entity" do
       user = build(:user, :with_entity)
-      DMCA.should_receive(:new).with(
+      expect(DMCA).to receive(:new).with(
         entity_notice_roles_attributes: [
           { name: 'recipient', entity_attributes: { name: 'Recipient' } },
           { name: 'submitter', entity_id: user.entity.id }
@@ -180,7 +180,7 @@ describe SubmitNotice, type: :model do
 
   def stub_new(klass)
     klass.new.tap do |instance|
-      klass.stub(:new).and_return(instance)
+      allow(klass).to receive(:new).and_return(instance)
     end
   end
 

--- a/spec/models/term_search_spec.rb
+++ b/spec/models/term_search_spec.rb
@@ -8,12 +8,12 @@ describe TermSearch, type: :model do
   end
 
   it "queries the searcher given a param it handles" do
-    @query.should_receive(:boolean)
+    expect(@query).to receive(:boolean)
     @term_search.apply_to_query(@query, :term, 'foo', nil)
   end
 
   it "does not query with a parameter it is not bound to" do
-    @query.should_not_receive(:boolean)
+    expect(@query).not_to receive(:boolean)
     @term_search.apply_to_query(@query, :unknown_term, 'foo', nil)
   end
 

--- a/spec/models/topic_manager_spec.rb
+++ b/spec/models/topic_manager_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe TopicManager, type: :model do
   context 'automatic validations' do
-    it { should validate_presence_of :name }
-    it { should validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
   end
-  it { should have_and_belong_to_many :topics }
+  it { is_expected.to have_and_belong_to_many :topics }
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 describe Topic, type: :model do
   context 'automatic validations' do
-    it { should validate_presence_of :name }
-    it { should validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
   end
 
-  it { should have_many(:topic_assignments).dependent(:destroy) }
-  it { should have_many(:notices).through(:topic_assignments) }
-  it { should have_many(:blog_entry_topic_assignments).dependent(:destroy) }
-  it { should have_many(:blog_entries).through(:blog_entry_topic_assignments) }
-  it { should have_and_belong_to_many :relevant_questions }
+  it { is_expected.to have_many(:topic_assignments).dependent(:destroy) }
+  it { is_expected.to have_many(:notices).through(:topic_assignments) }
+  it { is_expected.to have_many(:blog_entry_topic_assignments).dependent(:destroy) }
+  it { is_expected.to have_many(:blog_entries).through(:blog_entry_topic_assignments) }
+  it { is_expected.to have_and_belong_to_many :relevant_questions }
 
   context "#description_html" do
     it "converts #description from markdown" do
@@ -25,7 +25,7 @@ describe Topic, type: :model do
   context 'post update reindexing' do
     it "uses the TopicIndexQueuer to schedule notices for indexing" do
       topic = create(:topic)
-      TopicIndexQueuer.should_receive(:for).with(topic.id)
+      expect(TopicIndexQueuer).to receive(:for).with(topic.id)
 
       topic.save
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe User, type: :model do
-  it { should have_and_belong_to_many :roles }
+  it { is_expected.to have_and_belong_to_many :roles }
 
   context "#has_role?" do
     it "returns true when the user has the given role" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Work, type: :model do
-  it { should have_and_belong_to_many :notices }
-  it { should have_and_belong_to_many :infringing_urls }
-  it { should have_and_belong_to_many :copyrighted_urls }
+  it { is_expected.to have_and_belong_to_many :notices }
+  it { is_expected.to have_and_belong_to_many :infringing_urls }
+  it { is_expected.to have_and_belong_to_many :copyrighted_urls }
 
   context 'automatic validations' do
-    it { should validate_length_of(:kind).is_at_most(255) }
+    it { is_expected.to validate_length_of(:kind).is_at_most(255) }
   end
 
   context '.unknown' do
@@ -84,7 +84,7 @@ RSpec.describe Work, type: :model do
     end
 
     it "does not auto classify if kind is set" do
-      DeterminesWorkKind.any_instance.should_not_receive(:kind)
+      expect_any_instance_of(DeterminesWorkKind).not_to receive(:kind)
       work = build(:work, kind: 'foo')
 
       work.save

--- a/spec/rails_admin/config/actions/redact_notice_spec.rb
+++ b/spec/rails_admin/config/actions/redact_notice_spec.rb
@@ -7,7 +7,7 @@ describe "RedactNoticeProc" do
   before { setup_action_context }
 
   context "Handling GET requests" do
-    before { request.stub(:get?).and_return(true) }
+    before { allow(request).to receive(:get?).and_return(true) }
 
     it "sets the correct redactable fields" do
       instance_eval(&RedactNoticeProc)
@@ -33,16 +33,16 @@ describe "RedactNoticeProc" do
     end
 
     it "renders the action template for html" do
-      format.stub(:html).and_yield
-      @action.stub(:template_name).and_return('template_name')
+      allow(format).to receive(:html).and_yield
+      allow(@action).to receive(:template_name).and_return('template_name')
       should_receive(:render).with('template_name')
 
       instance_eval(&RedactNoticeProc)
     end
 
     it "renders with layout false for js" do
-      format.stub(:js).and_yield
-      @action.stub(:template_name).and_return('template_name')
+      allow(format).to receive(:js).and_yield
+      allow(@action).to receive(:template_name).and_return('template_name')
       should_receive(:render).with('template_name', layout: false)
 
       instance_eval(&RedactNoticeProc)
@@ -50,12 +50,12 @@ describe "RedactNoticeProc" do
   end
 
   context "Handling PUT requests" do
-    before { request.stub(:put?).and_return(true) }
+    before { allow(request).to receive(:put?).and_return(true) }
 
     it "delegates to the PutResponder" do
       responder = double("Put responder")
-      responder.should_receive(:handle).with(params)
-      PutResponder.should_receive(:new).
+      expect(responder).to receive(:handle).with(params)
+      expect(PutResponder).to receive(:new).
         with(self, @abstract_model, @object).and_return(responder)
 
       instance_eval(&RedactNoticeProc)
@@ -68,10 +68,10 @@ describe "RedactNoticeProc" do
           body_original: "B",
           review_required: "1"
         )
-        @object.should_receive(:body=).with("A")
-        @object.should_receive(:body_original=).with("B")
-        @object.should_receive(:review_required=).with("1")
-        @object.should_receive(:save)
+        expect(@object).to receive(:body=).with("A")
+        expect(@object).to receive(:body_original=).with("B")
+        expect(@object).to receive(:review_required=).with("1")
+        expect(@object).to receive(:save)
 
         put_responder.handle(params)
       end
@@ -82,17 +82,17 @@ describe "RedactNoticeProc" do
           body_original: "B",
           review_required: "1"
         )
-        @object.should_receive(:body=).with("A")
-        @object.should_receive(:body_original=).with("B")
-        @object.should_receive(:review_required=).with("1")
-        @object.should_receive(:save)
+        expect(@object).to receive(:body=).with("A")
+        expect(@object).to receive(:body_original=).with("B")
+        expect(@object).to receive(:review_required=).with("1")
+        expect(@object).to receive(:save)
 
         put_responder.handle(params)
       end
 
       it "calls handle_save_error on failure" do
         stub_notice_params
-        @object.stub(:save).and_return(false)
+        allow(@object).to receive(:save).and_return(false)
         should_receive(:handle_save_error).with(:redact_notice)
 
         put_responder.handle(params)
@@ -101,11 +101,11 @@ describe "RedactNoticeProc" do
       context "successful save" do
         before do
           stub_notice_params
-          @object.stub(:save).and_return(true)
+          allow(@object).to receive(:save).and_return(true)
         end
 
         it "redirects to the queue path" do
-          format.stub(:html).and_yield
+          allow(format).to receive(:html).and_yield
           should_receive(:redact_queue_path).
             with(@abstract_model).and_return(:some_path)
           should_receive(:redirect_to).with(:some_path)
@@ -116,7 +116,7 @@ describe "RedactNoticeProc" do
         it "redirects to next when appropriate" do
           params[:save_and_next] = true
           params[:next_notices] = %w( 1 2 3 )
-          format.stub(:html).and_yield
+          allow(format).to receive(:html).and_yield
           should_receive(:redact_notice_path).
             with(@abstract_model, '1', next_notices: %w( 2 3 )).
             and_return(:some_path)
@@ -126,8 +126,8 @@ describe "RedactNoticeProc" do
         end
 
         it "renders JSON for js requests" do
-          format.stub(:js).and_yield
-          @object.stub(:id).and_return(1)
+          allow(format).to receive(:js).and_yield
+          allow(@object).to receive(:id).and_return(1)
           should_receive(:render).with(json: { id: "1", label: "Redact notice" })
 
           put_responder.handle(params)
@@ -136,7 +136,7 @@ describe "RedactNoticeProc" do
     end
 
     def stub_notice_params(notice_params = {})
-      @abstract_model.stub(:param_key).and_return(:notice)
+      allow(@abstract_model).to receive(:param_key).and_return(:notice)
       params[:notice] = notice_params
     end
 
@@ -145,12 +145,12 @@ describe "RedactNoticeProc" do
   end
 
   context "Handling POST requests" do
-    before { request.stub(:post?).and_return(true) }
+    before { allow(request).to receive(:post?).and_return(true) }
 
     it "delegates to the PostResponder" do
       responder = double("Post responder")
-      responder.should_receive(:handle).with(params)
-      PostResponder.should_receive(:new).
+      expect(responder).to receive(:handle).with(params)
+      expect(PostResponder).to receive(:new).
         with(self, @abstract_model, @object).and_return(responder)
 
       instance_eval(&RedactNoticeProc)
@@ -163,7 +163,7 @@ describe "RedactNoticeProc" do
         redactor = expect_new(RedactsNotices, [
           expect_new(RedactsNotices::RedactsContent, "Sensitive thing")
         ])
-        redactor.should_receive(:redact_all).with([@object.id, 2, 3, 4])
+        expect(redactor).to receive(:redact_all).with([@object.id, 2, 3, 4])
         should_receive(:redact_notice_path).
           with(@abstract_model, 1, next_notices: %w( 2 3 4 )).
           and_return(:some_path)
@@ -177,7 +177,7 @@ describe "RedactNoticeProc" do
         redactor = stub_new(RedactsNotices, [
           stub_new(RedactsNotices::RedactsContent, "Sensitive thing")
         ])
-        redactor.should_receive(:redact_all).with([@object.id])
+        expect(redactor).to receive(:redact_all).with([@object.id])
         should_receive(:redact_notice_path).
           with(@abstract_model, 1, next_notices: nil).and_return(:some_path)
         should_receive(:redirect_to).with(:some_path)
@@ -197,13 +197,13 @@ describe "RedactNoticeProc" do
 
   def stub_new(klass, *args)
     klass.new(*args).tap do |instance|
-      klass.stub(:new).and_return(instance)
+      allow(klass).to receive(:new).and_return(instance)
     end
   end
 
   def expect_new(klass, *args)
     klass.new(*args).tap do |instance|
-      klass.should_receive(:new).with(*args).and_return(instance)
+      expect(klass).to receive(:new).with(*args).and_return(instance)
     end
   end
 end

--- a/spec/rails_admin/config/actions/redact_queue_spec.rb
+++ b/spec/rails_admin/config/actions/redact_queue_spec.rb
@@ -9,12 +9,12 @@ describe RedactQueueProc do
   context "GET request" do
     before do
       queue = stub_new(Redaction::Queue, current_user)
-      queue.stub(:notices).and_return([])
+      allow(queue).to receive(:notices).and_return([])
     end
 
     it "assigns a refill instance" do
       refill = Redaction::RefillQueue.new(params)
-      Redaction::RefillQueue.should_receive(:new).with(params).and_return(refill)
+      expect(Redaction::RefillQueue).to receive(:new).with(params).and_return(refill)
 
       instance_eval(&RedactQueueProc)
 
@@ -23,8 +23,8 @@ describe RedactQueueProc do
 
     it "assigns objects from the user's queue" do
       queue = Redaction::Queue.new(current_user)
-      queue.stub(:notices).and_return(:notices)
-      Redaction::Queue.should_receive(:new).with(current_user).and_return(queue)
+      allow(queue).to receive(:notices).and_return(:notices)
+      expect(Redaction::Queue).to receive(:new).with(current_user).and_return(queue)
 
       instance_eval(&RedactQueueProc)
 
@@ -32,16 +32,16 @@ describe RedactQueueProc do
     end
 
     it "renders the action template for html" do
-      format.stub(:html).and_yield
-      @action.stub(:template_name).and_return('template_name')
+      allow(format).to receive(:html).and_yield
+      allow(@action).to receive(:template_name).and_return('template_name')
       should_receive(:render).with('template_name')
 
       instance_eval(&RedactQueueProc)
     end
 
     it "renders with layout false for js" do
-      format.stub(:js).and_yield
-      @action.stub(:template_name).and_return('template_name')
+      allow(format).to receive(:js).and_yield
+      allow(@action).to receive(:template_name).and_return('template_name')
       should_receive(:render).with('template_name', layout: false)
 
       instance_eval(&RedactQueueProc)
@@ -49,13 +49,13 @@ describe RedactQueueProc do
   end
 
   context "POST request" do
-    before { request.stub(:post?).and_return(true) }
+    before { allow(request).to receive(:post?).and_return(true) }
 
     it "fills the users queue before redirecting" do
       params[:fill_queue] = true
       queue = stub_new(Redaction::Queue, current_user)
       refill = stub_new(Redaction::RefillQueue, params)
-      refill.should_receive(:fill).with(queue)
+      expect(refill).to receive(:fill).with(queue)
       should_redirect_back
 
       instance_eval(&RedactQueueProc)
@@ -84,7 +84,7 @@ describe RedactQueueProc do
           params[:selected] = %w( 1 3 5 9 )
           params[parameter] = true
           queue = stub_new(Redaction::Queue, current_user)
-          queue.should_receive(method).with(%w( 1 3 5 9 ))
+          expect(queue).to receive(method).with(%w( 1 3 5 9 ))
           should_redirect_back
 
           instance_eval(&RedactQueueProc)
@@ -95,7 +95,7 @@ describe RedactQueueProc do
 
   def stub_new(klass, *args)
     klass.new(*args).tap do |instance|
-      klass.stub(:new).and_return(instance)
+      allow(klass).to receive(:new).and_return(instance)
     end
   end
 

--- a/spec/renders_markdown_spec.rb
+++ b/spec/renders_markdown_spec.rb
@@ -8,7 +8,7 @@ describe Markdown do
   end
 
   it "reuses the same RedCarpet::Markdown instance" do
-    Redcarpet::Markdown.should_not_receive(:new)
+    expect(Redcarpet::Markdown).not_to receive(:new)
 
     Markdown.render("markdown")
     Markdown.render("markdown")

--- a/spec/serializers/notice_serializer_spec.rb
+++ b/spec/serializers/notice_serializer_spec.rb
@@ -23,7 +23,7 @@ describe NoticeSerializer do
 
   it 'includes a score attribute when the model responds to _score' do
     notice = build_notice
-    notice.stub(:_score).and_return(2)
+    allow(notice).to receive(:_score).and_return(2)
     serializer = NoticeSerializer.new(notice)
 
     score = serializer.as_json[:notice][:score]

--- a/spec/support/as_tire_result.rb
+++ b/spec/support/as_tire_result.rb
@@ -22,4 +22,15 @@ end
 
 RSpec.configure do |config|
   config.include AsTireResult
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end

--- a/spec/support/matchers/have_heading.rb
+++ b/spec/support/matchers/have_heading.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :have_heading do |heading|
     @page.has_css?("h2:contains('#{heading}')")
   end
 
-  failure_message_for_should do |_|
+  failure_message do |_|
     message = "expected page to have heading #{heading}"
 
     if element = @page.first('h2')

--- a/spec/support/matchers/key_with_value.rb
+++ b/spec/support/matchers/key_with_value.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :have_key do |key|
     @expected_value = value.is_a?(Array) ? value.sort : value
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     message  = "expected JSON hash to have key #{key.inspect}"
     message << " with value #{@expected_value.inspect}" if @check_value
     message << ", was #{@actual_value.inspect}"

--- a/spec/support/matchers/match_interface_of.rb
+++ b/spec/support/matchers/match_interface_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define :match_interface_of do
     missing_methods.empty?
   end
 
-  failure_message_for_should do
+  failure_message do
     "expected #{actual.name} to respond to #{missing_methods.join(', ')}"
   end
 

--- a/spec/support/shared_examples/filters.rb
+++ b/spec/support/shared_examples/filters.rb
@@ -6,25 +6,25 @@ shared_examples "a search filter" do
   end
 
   it "registers a facet" do
-    @searcher.should_receive(:facet)
+    expect(@searcher).to receive(:facet)
 
     @filter.register_filter(@searcher)
   end
 
   it "registers a filter" do
-    @searcher.should_receive(:filter)
+    expect(@searcher).to receive(:filter)
 
     @filter.apply_to_search(@searcher, :facet, '')
   end
 
   it "queries the searcher given a param it handles" do
-    @searcher.should_receive(:filter)
+    expect(@searcher).to receive(:filter)
 
     @filter.apply_to_search(@searcher, :facet, 'foo')
   end
 
   it "does not query with a parameter it is not bound to" do
-    @searcher.should_not_receive(:filter)
+    expect(@searcher).not_to receive(:filter)
 
     @filter.apply_to_search(@searcher, :unknown_term, 'foo')
   end

--- a/spec/support/shared_examples/object_with_url.rb
+++ b/spec/support/shared_examples/object_with_url.rb
@@ -10,11 +10,11 @@ shared_examples 'an object with a url' do
     'https://example.com/asdfasfd?foo=bar#bleep',
     'ftp://example.com'
   ].each do |good_url|
-    it { should allow_value(good_url).for(:url) }
+    it { is_expected.to allow_value(good_url).for(:url) }
   end
 
   ['', 'bee', 'brap.com', 1, nil].each do |bad_url|
-    it { should_not allow_value(bad_url).for(:url) }
+    it { is_expected.not_to allow_value(bad_url).for(:url) }
   end
 
 end

--- a/spec/support/shared_examples/redirecting_controller_for.rb
+++ b/spec/support/shared_examples/redirecting_controller_for.rb
@@ -1,7 +1,7 @@
 shared_examples 'a redirecting controller for' do |model_class, factory_name, id_method|
   it "redirects to a #{model_class} according to #{id_method}" do
     instance = build(factory_name, id: 1000)
-    model_class.should_receive(id_method).with('2000').and_return(instance)
+    expect(model_class).to receive(id_method).with('2000').and_return(instance)
 
     get :show, id: 2000
 
@@ -10,7 +10,7 @@ shared_examples 'a redirecting controller for' do |model_class, factory_name, id
   end
 
   it "gives a 404 when a mapping isn't found" do
-    model_class.should_receive(id_method).and_return(nil)
+    expect(model_class).to receive(id_method).and_return(nil)
     
     get :show, id: 2000
     

--- a/spec/support/shared_examples/serialized_notice_with_base_metadata.rb
+++ b/spec/support/shared_examples/serialized_notice_with_base_metadata.rb
@@ -40,15 +40,15 @@ end
 
 def build_notice(factory_name = :dmca)
   build(factory_name).tap do|notice|
-    notice.stub(:recipient_name).and_return('recipient name')
-    notice.stub(:sender_name).and_return('sender name')
-    notice.stub(:tag_list).and_return(['foo', 'bar'])
-    notice.stub(:jurisdiction_list).and_return(['US', 'CA'])
-    notice.stub(:language).and_return('en')
-    notice.stub(:topics).and_return(
+    allow(notice).to receive(:recipient_name).and_return('recipient name')
+    allow(notice).to receive(:sender_name).and_return('sender name')
+    allow(notice).to receive(:tag_list).and_return(['foo', 'bar'])
+    allow(notice).to receive(:jurisdiction_list).and_return(['US', 'CA'])
+    allow(notice).to receive(:language).and_return('en')
+    allow(notice).to receive(:topics).and_return(
       build_list(:topic, 2)
     )
-    notice.stub(:works).and_return(
+    allow(notice).to receive(:works).and_return(
       build_list(:work, 3, :with_infringing_urls, :with_copyrighted_urls)
     )
   end

--- a/spec/support/shared_examples/topic_assigner.rb
+++ b/spec/support/shared_examples/topic_assigner.rb
@@ -1,9 +1,9 @@
 shared_examples "a topic assigner of" do |topic_assigned_model|
-  it { should belong_to topic_assigned_model }
-  it { should belong_to :topic }
+  it { is_expected.to belong_to topic_assigned_model }
+  it { is_expected.to belong_to :topic }
 
   it {
-    should validate_uniqueness_of(:topic_id).
+    is_expected.to validate_uniqueness_of(:topic_id).
       scoped_to(:"#{topic_assigned_model}_id")
   }
 end

--- a/spec/views/blog_entries/index.html.erb_spec.rb
+++ b/spec/views/blog_entries/index.html.erb_spec.rb
@@ -68,7 +68,7 @@ describe 'blog_entries/index.html.erb' do
   end
 
   it "has a custom search engine" do
-    Chill::Application.config.stub(:google_custom_blog_search_id).and_return('yep')
+    allow(Chill::Application.config).to receive(:google_custom_blog_search_id).and_return('yep')
     blog_entries = mock_blog_entries
 
     render
@@ -79,10 +79,10 @@ describe 'blog_entries/index.html.erb' do
   def mock_blog_entries
     blog_entries = create_list(:blog_entry, 3, :with_abstract, :published)
     yield blog_entries if block_given?
-    blog_entries.stub(:total_entries).and_return(blog_entries.length)
-    blog_entries.stub(:total_pages).and_return(1)
-    blog_entries.stub(:current_page).and_return(1)
-    blog_entries.stub(:limit_value).and_return(1)
+    allow(blog_entries).to receive(:total_entries).and_return(blog_entries.length)
+    allow(blog_entries).to receive(:total_pages).and_return(1)
+    allow(blog_entries).to receive(:current_page).and_return(1)
+    allow(blog_entries).to receive(:limit_value).and_return(1)
     assign(:blog_entries, blog_entries)
     assign(:we_are_reading, [])
     blog_entries

--- a/spec/views/notices/search/index.html.erb_spec.rb
+++ b/spec/views/notices/search/index.html.erb_spec.rb
@@ -116,11 +116,11 @@ describe 'notices/search/index.html.erb' do
     allow(results).to receive(:limit_value).and_return(1)
 
     search_results = double('results double')
-    search_results.stub(:results).and_return(results)
+    allow(search_results).to receive(:results).and_return(results)
 
     searcher = double('searcher double')
-    searcher.stub(:search).and_return(search_results)
-    searcher.stub(:cache_key).and_return('asdfasdf')
+    allow(searcher).to receive(:search).and_return(search_results)
+    allow(searcher).to receive(:cache_key).and_return('asdfasdf')
     assign(:searcher, searcher)
   end
 

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'notices/show.html.erb' do
   before do
     @ability = Object.new
     @ability.extend(CanCan::Ability)
-    view.controller.stub(:current_ability) { @ability }
+    allow(view.controller).to receive(:current_ability) { @ability }
   end
 
   it "displays a metadata from a notice" do
@@ -18,7 +18,7 @@ describe 'notices/show.html.erb' do
 
   it "displays the date sent in the proper format" do
     notice = build(:dmca, date_sent: Time.local(2013, 5, 4))
-    notice.stub(:sender).and_return(build(:entity))
+    allow(notice).to receive(:sender).and_return(build(:entity))
     assign(:notice, notice)
 
     render
@@ -28,7 +28,7 @@ describe 'notices/show.html.erb' do
 
   it "displays the date received in the proper format" do
     notice = build(:dmca, date_received: Time.local(2013, 6, 5))
-    notice.stub(:recipient).and_return(build(:entity))
+    allow(notice).to receive(:recipient).and_return(build(:entity))
     assign(:notice, notice)
 
     render
@@ -110,7 +110,7 @@ describe 'notices/show.html.erb' do
   context "showing Principal" do
     it "displays the name as 'on behalf of principal' when differing" do
       notice = create(:dmca, role_names: %w( sender principal ))
-      notice.stub(:on_behalf_of_principal?).and_return(true)
+      allow(notice).to receive(:on_behalf_of_principal?).and_return(true)
       assign(:notice, notice)
 
       render
@@ -123,7 +123,7 @@ describe 'notices/show.html.erb' do
 
     it "does not display if not different" do
       notice = create(:dmca, role_names: %w( sender principal ))
-      notice.stub(:on_behalf_of_principal?).and_return(false)
+      allow(notice).to receive(:on_behalf_of_principal?).and_return(false)
       assign(:notice, notice)
 
       render
@@ -216,7 +216,7 @@ describe 'notices/show.html.erb' do
   it "displays limited related blog entries" do
     blog_entries = build_stubbed_list(:blog_entry, 3)
     notice = build(:dmca)
-    notice.stub(:related_blog_entries).and_return(blog_entries)
+    allow(notice).to receive(:related_blog_entries).and_return(blog_entries)
     assign(:notice, notice)
 
     render

--- a/spec/views/rails_admin/application/redact_notice.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_notice.html.erb_spec.rb
@@ -12,12 +12,12 @@ describe 'rails_admin/application/redact_notice.html.erb' do
 
     @ability = Object.new
     @ability.extend(CanCan::Ability)
-    controller.stub(:current_ability) { @ability }
+    allow(controller).to receive(:current_ability) { @ability }
   end
 
   it 'displays elapsed time in queue' do
     notice = build_stubbed(:dmca)
-    notice.stub(:created_at).and_return(2.hours.ago)
+    allow(notice).to receive(:created_at).and_return(2.hours.ago)
     assign(:object, notice)
 
     render

--- a/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe 'rails_admin/application/redact_queue.html.erb' do
     # in the view spec context, the default url for the form_tag is not
     # a valid route for some reason. there's no testable behavior there
     # anyway, so we'll just stub it out.
-    view.stub(:form_tag).and_yield
+    allow(view).to receive(:form_tag).and_yield
 
     assign(:refill, double(each_input: nil))
     assign(:objects, [])

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe 'shared/_footer.html.erb' do
 
   context 'signed in' do
     it 'gives a link to the admin' do
-      controller.stub(user_signed_in?: true)
+      allow(controller).to receive_messages(user_signed_in?: true)
 
       render
 


### PR DESCRIPTION
This conversion is done by Transpec 3.2.2 with the following command:
    transpec

* 97 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 79 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 75 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 19 conversions
    from: expect(collection).to have(n).items
      to: expect(collection.size).to eq(n)

* 8 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 8 conversions
    from: obj.stub_chain(:message1, :message2)
      to: allow(obj).to receive_message_chain(:message1, :message2)

* 3 conversions
    from: failure_message_for_should { }
      to: failure_message { }

* 3 conversions
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

* 2 conversions
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 1 conversion
    from: Klass.any_instance.should_not_receive(:message)
      to: expect_any_instance_of(Klass).not_to receive(:message)

* 1 conversion
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

* 1 conversion
    from: stub('something')
      to: double('something')

* 1 addition
      of: RSpec.configure { |c| c.infer_spec_type_from_file_location! }

For more details: https://github.com/yujinakayama/transpec#supported-conversions