### PR TITLE
Fix broken duplicate url tests

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -30,17 +30,11 @@ RSpec.describe Work, type: :model do
       existing_infringing_url = create(
         :infringing_url, url: 'http://www.example.com/infringe'
       )
-      duplicate_infringing_url = build(
-        :infringing_url, url: 'http://www.example.com/infringe'
-      )
-      new_infringing_url = build(
-        :infringing_url, url: 'http://example.com/new'
-      )
-
-      work = build(
-        :work,
-        infringing_urls: [duplicate_infringing_url, new_infringing_url]
-      )
+      params = { work: { description: 'Test', infringing_urls_attributes:
+        [{ url: 'http://www.example.com/infringe' },
+         { url: 'http://example.com/new' }] } }
+      work = Work.new(params[:work])
+      work.save
       work.save
 
       work.reload
@@ -55,17 +49,11 @@ RSpec.describe Work, type: :model do
       existing_copyrighted_url = create(
         :copyrighted_url, url: 'http://www.example.com/copyrighted'
       )
-      duplicate_copyrighted_url = build(
-        :copyrighted_url, url: 'http://www.example.com/copyrighted'
-      )
-      new_copyrighted_url = build(
-        :copyrighted_url, url: 'http://example.com/new'
-      )
 
-      work = build(
-        :work,
-        copyrighted_urls: [duplicate_copyrighted_url, new_copyrighted_url]
-      )
+      params = { work: { description: 'Test', copyrighted_urls_attributes:
+        [{ url: 'http://www.example.com/copyrighted' },
+         { url: 'http://example.com/new' }] } }
+      work = Work.new(params[:work])
       work.save
 
       work.reload


### PR DESCRIPTION
For unknown reasons when running the tests with FactoryGirl the two modified tests fail due to a Postgres unique violation. The difference between Rails 3.2 and 4.2 is the appearance of the following at the end of the Factory creation:

  SQL (0.4ms)  INSERT INTO "copyrighted_urls" ("url", "url_original", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["url", "http://www.example.com/copyrighted"], ["url_original", "http://www.example.com/copyrighted"], ["created_at", "2016-07-25 19:08:48.450078"], ["updated_at", "2016-07-25 19:08:48.450078"]]

Manual testing of the functionality in rails console revealed the functionality works as expected, but the test does not. Switching to pure ruby instead of abstracting in FactoryGirl lead to getting these tests to pass for now.