### PR TITLE
Fixes failing catch invalid json test

### DIFF
--- a/app/middleware/catch_json_parsing_errors.rb
+++ b/app/middleware/catch_json_parsing_errors.rb
@@ -6,12 +6,12 @@ class CatchJsonParsingErrors
   def call(env)
     begin
       @app.call(env)
-    rescue MultiJson::LoadError => error
+    rescue ActionDispatch::ParamsParser::ParseError => error
       if env['HTTP_ACCEPT'] =~ /application\/json/i
         error_output = "There was a problem in the JSON you submitted: #{error}"
         return [
           400, { "Content-Type" => "application/json" },
-          [ { status: 400, error: error_output }.to_json ]
+          [{ status: 400, error: error_output }.to_json]
         ]
       else
         raise error


### PR DESCRIPTION
Fixes client_submits_invalid_json_spec.rb:6 using method described at https://robots.thoughtbot.com/catching-json-parse-errors-with-custom-middleware.