### PR TITLE
Update expected error

### DIFF
--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -30,7 +30,7 @@ describe TopicsController do
     it "cannot be routed" do
       expect do
         get(:index, format: :html)
-      end.to raise_error(ActionController::RoutingError)
+      end.to raise_error(ActionController::UrlGenerationError)
     end
   end
 


### PR DESCRIPTION
Rails 4.2 is providing a different error than Rails 3.2 provided, but we are indifferent to what the error is as long as it does not generate an html page. This changes the test to accept the updated error.