### PR TITLE
Stringify url_relation to fix failing tests

### DIFF
--- a/spec/lib/question_importer_spec.rb
+++ b/spec/lib/question_importer_spec.rb
@@ -33,8 +33,8 @@ OriginalNoticeID,Question
 
     notice_1 = Notice.where(original_notice_id: 1).first
     notice_2 = Notice.where(original_notice_id: 2).first
-    expect(notice_1.size).to eq(1)
-    expect(notice_2.size).to eq(1)
+    expect(notice_1.relevant_questions.size).to eq(1)
+    expect(notice_2.relevant_questions.size).to eq(1)
   end
 
   it "does not clobber existing relevant questions" do
@@ -46,6 +46,6 @@ OriginalNoticeID,Question
 
     QuestionImporter.new(sample_file).import
 
-    expect(notice.reload.size).to eq(3)
+    expect(notice.reload.relevant_questions.size).to eq(3)
   end
 end

--- a/spec/serializers/notice_serializer_spec.rb
+++ b/spec/serializers/notice_serializer_spec.rb
@@ -12,7 +12,8 @@ describe NoticeSerializer do
   %i|infringing_urls copyrighted_urls|.each do |url_relation|
     it "includes #{url_relation}" do
       with_a_serialized_notice do |notice, json|
-        relation_json = json[:works].first[url_relation].map{|u| u['url']}
+        binding.pry
+        relation_json = json[:works].first[url_relation.to_s].map{|u| u['url']}
         expect(relation_json).to eq(
           notice.works.first.send(url_relation).map(&:url)
         )

--- a/spec/serializers/notice_serializer_spec.rb
+++ b/spec/serializers/notice_serializer_spec.rb
@@ -12,7 +12,6 @@ describe NoticeSerializer do
   %i|infringing_urls copyrighted_urls|.each do |url_relation|
     it "includes #{url_relation}" do
       with_a_serialized_notice do |notice, json|
-        binding.pry
         relation_json = json[:works].first[url_relation.to_s].map{|u| u['url']}
         expect(relation_json).to eq(
           notice.works.first.send(url_relation).map(&:url)


### PR DESCRIPTION
* Two failing tests were the result of url_relation tyring to access an array as a symbol instead of a string. Coercing url_relation to a string fixes this.