### PR TITLE
Fix broken serializers

### DIFF
--- a/app/models/court_order.rb
+++ b/app/models/court_order.rb
@@ -12,4 +12,9 @@ class CourtOrder < Notice
   def to_partial_path
     'notices/notice'
   end
+
+  def laws_referenced
+    tag_ids = self.taggings.where(context: 'regulations').pluck(:tag_id)
+    ActsAsTaggableOn::Tag.find(tag_ids)
+  end
 end

--- a/app/models/law_enforcement_request.rb
+++ b/app/models/law_enforcement_request.rb
@@ -24,4 +24,9 @@ class LawEnforcementRequest < Notice
   def to_partial_path
     'notices/notice'
   end
+
+  def regulation_list
+    tag_ids = self.taggings.where(context: 'regulations').pluck(:tag_id)
+    ActsAsTaggableOn::Tag.find(tag_ids)
+  end
 end

--- a/app/serializers/court_order_serializer.rb
+++ b/app/serializers/court_order_serializer.rb
@@ -2,7 +2,7 @@ class CourtOrderSerializer < NoticeSerializer
   attribute :laws_referenced
 
   def laws_referenced
-    object.regulation_list
+    object.laws_referenced.map(&:name)
   end
 
   private
@@ -12,8 +12,8 @@ class CourtOrderSerializer < NoticeSerializer
     swap_keys(attributes, :body, :explanation)
     attributes[:works].each do |work|
       swap_keys(work, 'description', :subject_of_court_order)
-      swap_keys(work, :infringing_urls, :targetted_urls)
-      work.delete(:copyrighted_urls)
+      swap_keys(work, 'infringing_urls', :targetted_urls)
+      work.delete('copyrighted_urls')
     end
     attributes
   end

--- a/app/serializers/law_enforcement_request_serializer.rb
+++ b/app/serializers/law_enforcement_request_serializer.rb
@@ -2,7 +2,7 @@ class LawEnforcementRequestSerializer < NoticeSerializer
   attributes :regulations, :request_type
 
   def regulations
-    object.regulation_list
+    object.regulation_list.map(&:name)
   end
 
   private


### PR DESCRIPTION
* Fix CourtOrders and LawEnforcmentRequests to serialize appropriately.
* This ugly hack is due to the fact that AMS 0.8.3 seemed to fail at accessing regulation_list. Presumably due to a bug.